### PR TITLE
Added JaCoCo and Coveralls support to build.gradle and travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+
+after_success:
+- ./gradlew jacocoTestReport coveralls

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Coverage Status](https://coveralls.io/repos/github/22d3e06/instalist-server/badge.svg?branch=master)](https://coveralls.io/github/22d3e06/instalist-server?branch=master)
+
 # InstaList Server
 This is the server-side for the plugin [Instalist Synch](https://github.com/InstaList/instalist-synch).
 It holds a central database and allows clients organized in groups to access data.

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
 plugins {
-  id "org.sonarqube" version "2.3"
+    id "org.sonarqube" version "2.3"
+    id 'jacoco'
+    id 'com.github.kt3k.coveralls' version '2.8.1'
 }
+
 apply plugin: 'java'
 apply plugin: 'war'
 apply plugin: 'idea'
@@ -10,6 +13,13 @@ version = '0.1-SNAPSHOT'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
+
+jacocoTestReport {
+    reports {
+        xml.enabled = true // coveralls plugin depends on xml format report
+        html.enabled = true
+    }
+}
 
 repositories {
     mavenCentral()
@@ -22,19 +32,18 @@ subprojects {
 
 dependencies {
     compile project(':instalist-comm')
-    compile group: 'org.glassfish.jersey.containers', name: 'jersey-container-servlet', version:'2.22.2'
-    compile group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson', version:'2.22.2'
-    compile group: 'com.fasterxml.jackson.jaxrs', name: 'jackson-jaxrs-base', version:'2.7.3'
-    compile group: 'com.fasterxml.jackson.jaxrs', name: 'jackson-jaxrs-json-provider', version:'2.7.3'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version:'2.7.3'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version:'2.7.3'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.7.3'
-    compile group: 'org.mariadb.jdbc', name: 'mariadb-java-client', version:'1.3.4'
-    compile group: 'de.svenkubiak', name: 'jBCrypt', version:'0.4.1'
-    compile group: 'org.hibernate', name: 'hibernate-entitymanager', version:'5.1.0.Final'
-    compile group: 'org.hibernate', name: 'hibernate-java8', version:'5.1.0.Final'
-    testCompile group: 'org.glassfish.jersey.test-framework.providers', name: 'jersey-test-framework-provider-simple', version:'2.22.2'
-    testCompile group: 'com.h2database', name: 'h2', version:'1.4.191'
+    compile group: 'org.glassfish.jersey.containers', name: 'jersey-container-servlet', version: '2.22.2'
+    compile group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson', version: '2.22.2'
+    compile group: 'com.fasterxml.jackson.jaxrs', name: 'jackson-jaxrs-base', version: '2.7.3'
+    compile group: 'com.fasterxml.jackson.jaxrs', name: 'jackson-jaxrs-json-provider', version: '2.7.3'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.7.3'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.7.3'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.7.3'
+    compile group: 'org.mariadb.jdbc', name: 'mariadb-java-client', version: '1.3.4'
+    compile group: 'de.svenkubiak', name: 'jBCrypt', version: '0.4.1'
+    compile group: 'org.hibernate', name: 'hibernate-entitymanager', version: '5.1.0.Final'
+    compile group: 'org.hibernate', name: 'hibernate-java8', version: '5.1.0.Final'
+    testCompile group: 'org.glassfish.jersey.test-framework.providers', name: 'jersey-test-framework-provider-simple', version: '2.22.2'
+    testCompile group: 'com.h2database', name: 'h2', version: '1.4.191'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
-


### PR DESCRIPTION
Hozzáadtam a projekthez a JaCoCo és a Coveralls gradle plugineket. Az előbbi méri a kód lefedettséget, az utóbbi pedig feltölti a Coveralls webes felületére.
A Travis konfigurációt is módosítottam, hogy sikeres build után fusson le ez a két Gradle task.